### PR TITLE
refactor: simplify icon and logo download to use direct URLs

### DIFF
--- a/.github/workflows/generator-windows-x86.yml
+++ b/.github/workflows/generator-windows-x86.yml
@@ -276,8 +276,11 @@ jobs:
       - name: magick stuff
         if: ${{ inputs.iconlink != 'false' }}
         continue-on-error: true
+        shell: bash
         run: |
-          Invoke-WebRequest -Uri ${{ fromJson(inputs.iconlink).url }}/get_png?filename=${{ fromJson(inputs.iconlink).file }}"&"uuid=${{ fromJson(inputs.iconlink).uuid }} -OutFile ./res/icon.png 
+          echo "Downloading icon from: ${{ inputs.iconlink }}"
+          curl -L -o ./res/icon.png "${{ inputs.iconlink }}"
+
           mv ./res/32x32.png ./res/32x32.png.bak
           mv ./res/64x64.png ./res/64x64.png.bak
           mv ./res/128x128.png ./res/128x128.png.bak

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -337,8 +337,11 @@ jobs:
       - name: magick stuff
         if: ${{ inputs.iconlink != 'false' }}
         continue-on-error: true
+        shell: bash
         run: |
-          Invoke-WebRequest -Uri ${{ fromJson(inputs.iconlink).url }}/get_png?filename=${{ fromJson(inputs.iconlink).file }}"&"uuid=${{ fromJson(inputs.iconlink).uuid }} -OutFile ./res/icon.png 
+          echo "Downloading icon from: ${{ inputs.iconlink }}"
+          curl -L -o ./res/icon.png "${{ inputs.iconlink }}"
+
           mv ./res/32x32.png ./res/32x32.png.bak
           mv ./res/64x64.png ./res/64x64.png.bak
           mv ./res/128x128.png ./res/128x128.png.bak
@@ -462,8 +465,10 @@ jobs:
       - name: logo stuff
         if: ${{ inputs.logolink != 'false' }}
         continue-on-error: true
+        shell: bash
         run: |
-          Invoke-WebRequest -Uri ${{ fromJson(inputs.logolink).url }}/get_png?filename=${{ fromJson(inputs.logolink).file }}"&"uuid=${{ fromJson(inputs.logolink).uuid }} -OutFile ./rustdesk/data/flutter_assets/assets/logo.png
+          echo "Downloading logo from: ${{ inputs.logolink }}"
+          curl -L -o ./rustdesk/data/flutter_assets/assets/logo.png "${{ inputs.logolink }}"
 
       - name: find Runner.res
         # Windows: find Runner.res (compiled from ./flutter/windows/runner/Runner.rc), copy to ./Runner.res


### PR DESCRIPTION
- Updated "magick stuff" step to download icon directly from iconlink URL
  * Removed complex URL construction with get_png?filename=...&uuid=...
  * Now uses simple direct URL via curl
  * Applied to both generator-windows.yml and generator-windows-x86.yml

- Updated "logo stuff" step to download logo directly from logolink URL
  * Changed from PowerShell Invoke-WebRequest to bash curl
  * Simplified URL handling

- Changed shell to bash for consistency in both steps
- Added echo statements for better logging

Before: iconlink expected JSON with url, file, uuid structure
After: iconlink expects simple direct URL to PNG file

🤖 Generated with [Claude Code](https://claude.com/claude-code)