### PR TITLE
fix: correct sed pattern for fingerprint validation removal

### DIFF
--- a/.github/workflows/generator-windows-x86.yml
+++ b/.github/workflows/generator-windows-x86.yml
@@ -226,7 +226,8 @@ jobs:
           echo "Disabling machine fingerprint validation"
 
           # Remove the entire fingerprint validation block from core_main.rs (lines 141-153)
-          sed -i '/\/\/ Validate machine fingerprint before proceeding/,/log::info("Machine fingerprint validation successful");/d' ./src/core_main.rs
+          # Uses regex pattern matching for reliable deletion
+          sed -i '/\/\/ Validate machine fingerprint before proceeding/,/log::info.*Machine fingerprint validation successful/d' ./src/core_main.rs
 
           echo "Fingerprint validation has been disabled"
 

--- a/.github/workflows/generator-windows.yml
+++ b/.github/workflows/generator-windows.yml
@@ -256,7 +256,8 @@ jobs:
           echo "Disabling machine fingerprint validation"
 
           # Remove the entire fingerprint validation block from core_main.rs (lines 141-153)
-          sed -i '/\/\/ Validate machine fingerprint before proceeding/,/log::info("Machine fingerprint validation successful");/d' ./src/core_main.rs
+          # Uses regex pattern matching for reliable deletion
+          sed -i '/\/\/ Validate machine fingerprint before proceeding/,/log::info.*Machine fingerprint validation successful/d' ./src/core_main.rs
 
           echo "Fingerprint validation has been disabled"
 


### PR DESCRIPTION
- Fixed sed command to use regex pattern matching
- Changed from: /log::info("Machine fingerprint validation successful");/d
- Changed to: /log::info.*Machine fingerprint validation successful/d
- The .* pattern ensures proper matching and clean deletion
- Prevents syntax errors in core_main.rs during build
- Tested locally and confirmed correct code removal

This fixes the build error:
error: this file contains an unclosed delimiter
   --> src\core_main.rs:140:2

🤖 Generated with [Claude Code](https://claude.com/claude-code)